### PR TITLE
Thay đổi hướng dẫn cài đặt trên Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,11 +250,11 @@ sudo udevadm control --reload
 
 * You can skip this step if the Arduino IDE has been installed before.
 
-* Download suitable software at [HERE](http://arduino.cc/en/Main/Software) and then install.s
+* Download suitable software at [HERE](http://arduino.cc/en/Main/Software) and then install.
 
 
 ### 3. Install packages of VBLUno board for Arduino IDE
-You can install by one of two methods following
+You can install with one of two following methods:
 
 **_Method 1: Install online_**
 
@@ -267,12 +267,12 @@ You can install by one of two methods following
 
 **_Method 2: Install offline_**
 
-  * You should be sured Arduino IDE cannot be opened while install offline.
+  * You should be sure that Arduino IDE is not opened while installing offline.
 
   * Download suitable softwares for OS:
     * [For Windows](https://github.com/VNGIoTLab/Arduino_VBLUno_nRF51822/tree/master/Setup_Offline/Windows)
     * [For Linux](https://github.com/VNGIoTLab/Arduino_VBLUno_nRF51822/tree/master/Setup_Offline/Linux)
-	* [For MacOSX](https://github.com/VNGIoTLab/Arduino_VBLUno_nRF51822/tree/master/Setup_Offline/Mac)
+    * [For MacOSX](https://github.com/VNGIoTLab/Arduino_VBLUno_nRF51822/tree/master/Setup_Offline/Mac)
 
   * Extract and run setup file
     * Windows: Setup_VBLUno_Windows.exe
@@ -284,24 +284,24 @@ You can install by one of two methods following
 
 `sudo ./Setup_VBLUno_Linux`
 
-   * You have to wait until the program announce “The installation was successful”
+  * You have to wait until the program announces “The installation was successful”
 
-  * Note: Preferences->Additional Boards Manager URLs always has this content (You can add multiple URLs, separating them with commas):
+  * Note: _Preferences->Additional Boards Manager_ URLs always has this content (You can add multiple URLs, separating them with commas):
   `https://raw.githubusercontent.com/VNGIoTLab/Arduino_VBLUno_nRF51822/master/package_vngiotlab_vbluno_index.json`
 
 ## Bootloaders
 
-* Bootloader helps Arduino IDE can upload firmware for VBLUno boards via serial ports.  VBLUno boards are sold , bootloaders are preloaded. **_Normally, you can skip this step._**
+* Bootloader helps Arduino IDE upload firmware to VBLUno boards via serial ports.  VBLUno boards sold on the market already includes bootloaders. **_Normally, you can skip this step._**
 
-* In the folder is named "VBLUno_nRF51822_board\bootloader", it contains bootloader_38400.hex and  source code.
+* In the "VBLUno_nRF51822_board\bootloader" folder, there are bootloader_38400.hex and its source code.
 
-* To load bootloader, connect the board with your PC, using a CMSIS-DAP module via SWD interface (J5), it will create a virtual disk (MBED), drag and drop bootloader.hex into this disk.
+* To load bootloader, connect the board with your PC, use a CMSIS-DAP module via SWD interface (J5), it will create a virtual disk (MBED). Drag and drop bootloader.hex into this disk.
 
 ## How to play
 
 **1. Connect VBLUno board to PC via USB port**
 
-  * Switch bridge at jump J7 to position allow to upload firmware through serial ports (USB ports on VBLUno boards) by bootloaders (position 1-2, near black Power jack).
+  * Switch bridge at jump J7 to the position which allows to upload firmware via serial ports (USB ports on VBLUno boards) by bootloaders (position 1-2, near black Power jack).
 
   * Then press Reset button. At this time, two Leds on board are lighting up.
 

--- a/README.md
+++ b/README.md
@@ -51,19 +51,28 @@ Phiên bản: v1.0.4 (Bổ sung gói cài đặt online cho MacOSX). Trước kh
 * Nếu đã cài đặt, bạn có thể  bỏ qua bước này
 
 * Thực hiện: Tải trình điều khiển phù hợp tại [ĐÂY](https://www.silabs.com/products/mcu/Pages/USBtoUARTBridgeVCPDrivers.aspx) và cài đặt vào máy
-          
+
+* Nếu sử dụng Linux, bạn không cần trình điều khiển, nhưng cần tạo udev rule để yêu cầu hệ thống tự  thay đổi quyền truy cập thiết bị "USB to UART". Bạn tạo file _90-arduino-usb0.rules_ với nội dung như sau:
+
+```
+# Set owner "user" for Serial-to-USB device
+SUBSYSTEM=="tty", KERNEL=="ttyUSB0", OWNER="user"
+```
+
+nhưng thay thế _user_ với username Linux của bạn. Sau đó copy file vào _/etc/udev/rules.d/_
+
+```sh
+sudo cp 90-arduino-usb0.rules /etc/udev/rules.d/
+sudo udevadm control --reload
+```
+
 
 ### 2. Cài đặt Arduino IDE
 
 * Nếu đã cài đặt, bạn có thể  bỏ qua bước này
 
-* Thực hiện: Tải bản cài đặt phù hợp tại [ĐÂY](http://arduino.cc/en/Main/Software) và cài đặt vào máy. 
+* Thực hiện: Tải bản cài đặt phù hợp tại [ĐÂY](http://arduino.cc/en/Main/Software) và cài đặt vào máy.
 
-* Chú ý: Nếu bạn đang sử dụng hệ điều hành Linux (tương tự với MacOSX), cần chạy Arduino IDE với quyền root. Điều này giúp Arduino IDE có thể mở cổng nối tiếp (UART) để nạp firmware cho mạch VBLUno.
-    * Mở Terminal (Ctrl + Alt + T)
-    * Chuyển đến thư mục đã cài đặt Arduino bằng cách sử dụng lệnh “cd”. 
-                       Ví dụ cd /home/mrABC/arduino-1.6.10
-    * Mở Arduino IDE với lệnh sudo: sudo ./aduino
 
 
 ### 3. Cài đặt gói dữ liệu của mạch VBLUno cho Arduino IDE
@@ -71,39 +80,39 @@ Phiên bản: v1.0.4 (Bổ sung gói cài đặt online cho MacOSX). Trước kh
 **_Cách 1: Cài đặt online_**
 
   * Chạy Arduino IDE, vào menu File, chọn "Preferences", thêm dòng sau vào ô  "Additional Boards Manager URLs": `https://raw.githubusercontent.com/VNGIoTLab/Arduino_VBLUno_nRF51822/master/package_vngiotlab_vbluno_index.json`
-  *Chú ý: * Bạn có thể thêm nhiều địa chỉ URLs tại đây, phân tách chúng bởi dấy phẩy. 	 
-  
-     
-  * Cài đặt dữ liệu "VNGIoTLab VBLUno nRF51822 Boards" thông qua Trình quản lý boards (Boards Manager) 
+  *Chú ý: * Bạn có thể thêm nhiều địa chỉ URLs tại đây, phân tách chúng bởi dấy phẩy.
+
+
+  * Cài đặt dữ liệu "VNGIoTLab VBLUno nRF51822 Boards" thông qua Trình quản lý boards (Boards Manager)
     * Từ menu: Tools -> Board -> Boards Manager ...
     * Chọn VNGIoTLab VBLUno nRF51822 Boards và nhấn Install
 
 **_Cách 2: Cài đặt offline_**
 
   * Bạn cần chắc chắn Arduino IDE không được mở trong quá trình cài đặt offline.
-     
-  * Tải bản cài đặt phù hợp với hệ điều hành: 
+
+  * Tải bản cài đặt phù hợp với hệ điều hành:
     * [Cho Windows](https://github.com/VNGIoTLab/Arduino_VBLUno_nRF51822/tree/master/Setup_Offline/Windows)
     * [Cho Linux](https://github.com/VNGIoTLab/Arduino_VBLUno_nRF51822/tree/master/Setup_Offline/Linux)
 	* [Cho MacOSX](https://github.com/VNGIoTLab/Arduino_VBLUno_nRF51822/tree/master/Setup_Offline/Mac)
-	  
 
-  * Giải nén và chạy file cài đặt 
+
+  * Giải nén và chạy file cài đặt
     * Windows: Setup_VBLUno_Windows.exe
-    * Linux: 
-    
+    * Linux:
+
 `cd Setup_Offline_VBLUno_Linux_xxx`
 
-`sudo chmod 777 Setup_VBLUno_Linux`
+`chmod a+x Setup_VBLUno_Linux`
 
 `sudo ./Setup_VBLUno_Linux` . Chú ý phải sử dụng lệnh sudo
 
    * Bạn chờ đến khi chương trình thông báo “The installation was successful” là quá trình cài đặt đã hoàn thành.
-  
+
   * Chú ý: Từ bây giờ, tại Preferences->Additional Boards Manager URLs luôn phải có nội dung sau (các packages khác nhau được phân tách bởi dấy phẩy):
   `https://raw.githubusercontent.com/VNGIoTLab/Arduino_VBLUno_nRF51822/master/package_vngiotlab_vbluno_index.json`
 ## Bootloaders
-	
+
 * Bootloader giúp Arduino IDE nạp firmware cho VBLUno thông qua cổng USB gắn trên mạch (USB to UART). Mạch VBLUno khi bán ra đã được nạp sẵn bootloader. **_Thông thường, bạn có thể bỏ qua bước này._**
 
 * Trong thư mục "VBLUno_nRF51822_board\bootloader" có chứa file bootloader_38400.hex và mã nguồn tương ứng. Đây là bootloader cho phép Arduino IDE nạp (upload) firmware xuống VBLUno thông qua cổng nối tiếp.
@@ -115,7 +124,7 @@ Phiên bản: v1.0.4 (Bổ sung gói cài đặt online cho MacOSX). Trước kh
 **1. Kết nối mạch VBLUno với PC thông qua cổng USB trên mạch.**
 
   * Chuyển cầu nối trên jump J7 về vị trí cho phép nạp firmware qua cổng USB bằng bootloader (vị trí 1-2, gần phía Jack nguồn màu đen).
-     
+
   * Sau đó ấn nút Reset. Lúc này quan sát thấy sáng cả 2 led trên mạch.
 
 **2. Mở Arduino IDE trên PC**
@@ -134,7 +143,7 @@ Phiên bản: v1.0.4 (Bổ sung gói cài đặt online cho MacOSX). Trước kh
     * Menu > File > Examples > 01.Basics > Blink
 
   * Sử dụng chức năng upload (Menu -> Sketch -> Upload) để biên dịch chương trình và nạp firmware xuống mạch VBLUno.
-     
+
   * Nếu biên dịch và nạp thành công, bạn sẽ nhận được thông báo “Device programmed”
 
   * Chuyển cầu nối trên jump J7 về vị trí cho phép chạy Application (vị trí 2-3, gần phía cổng USB)
@@ -154,7 +163,7 @@ Phiên bản: v1.0.4 (Bổ sung gói cài đặt online cho MacOSX). Trước kh
 	*BLE Controller*: This example allows you to use the BLE Controller App (available for iOS and Android) to control the pin state such as High, Low, PWM, Analog, etc.
 
 	*BLE Serial*: This example allows you to exchange data with your central device (e.g. iPhone 5) and the data will be redirected to the UART.
-	
+
 	*.....*
 
 
@@ -219,22 +228,29 @@ Version: v1.0.4 (Add installation for MacOSX). Before update version, you need t
 
 ### 1. Install driver for chip CP210x – USB to UART
 
-* If you installed, you can pass this step
+* You can skip this step if the driver has been installed before.
 
 * Download suitable drivers at [HERE](https://www.silabs.com/products/mcu/Pages/USBtoUARTBridgeVCPDrivers.aspx) and then install
-          
+
+* If you are using Linux, you don't need driver. But you need to make an udev rule to tell the system to change permission on "USB to UART" device. Create a file _90-arduino-usb0.rules_ with this content:
+
+```
+# Set owner "user" for Serial-to-USB device
+SUBSYSTEM=="tty", KERNEL=="ttyUSB0", OWNER="user"
+```
+
+Replace _user_ with your Linux username and copy to _/etc/udev/rules.d/_
+
+```sh
+sudo cp 90-arduino-usb0.rules /etc/udev/rules.d/
+sudo udevadm control --reload
+```
 
 ### 2. Install Arduino IDE
 
-* If you installed, you can pass this step
+* You can skip this step if the Arduino IDE has been installed before.
 
-* Download suitable software at [HERE](http://arduino.cc/en/Main/Software) and then install.
-
-* Note: If you are using a Linux OS (MacOSX), you need to run Arduino IDE with root permission. This can help Arduino can open serial ports to upload firmware for VBLUno kit.
-    * Open Terminal (Ctrl + Alt + T)
-    * Moving  to directory which is already installed  Arduino by using “cd” command.
-                       For example: cd /home/mrABC/arduino-1.6.10
-    * Open Arduino IDE by “sudo” command:  sudo ./aduino
+* Download suitable software at [HERE](http://arduino.cc/en/Main/Software) and then install.s
 
 
 ### 3. Install packages of VBLUno board for Arduino IDE
@@ -244,7 +260,7 @@ You can install by one of two methods following
 
   * Open Arduino IDE, at File,select "Preferences", add the following line to "Additional Boards Manager URLs": https://raw.githubusercontent.com/VNGIoTLab/Arduino_VBLUno_nRF51822/master/package_vngiotlab_vbluno_index.json
   (You can add multiple URLs, separating them with commas)
-     
+
   * Install the "VNGIoTLab VBLUno nRF51822 Boards" add-on via Boards Manager
     * From menu bar: Tools -> Board -> Boards Manager ...
     * Select VNGIoTLab VBLUno nRF51822 Boards and then click  Install
@@ -252,29 +268,29 @@ You can install by one of two methods following
 **_Method 2: Install offline_**
 
   * You should be sured Arduino IDE cannot be opened while install offline.
-     
-  * Download suitable softwares for OS: 
+
+  * Download suitable softwares for OS:
     * [For Windows](https://github.com/VNGIoTLab/Arduino_VBLUno_nRF51822/tree/master/Setup_Offline/Windows)
     * [For Linux](https://github.com/VNGIoTLab/Arduino_VBLUno_nRF51822/tree/master/Setup_Offline/Linux)
 	* [For MacOSX](https://github.com/VNGIoTLab/Arduino_VBLUno_nRF51822/tree/master/Setup_Offline/Mac)
-	
+
   * Extract and run setup file
     * Windows: Setup_VBLUno_Windows.exe
-    * Linux: 
-    
+    * Linux:
+
 `cd Setup_Offline_VBLUno_Linux_xxx`
 
-`sudo chmod 777 Setup_VBLUno_Linux`
+`chmod a+x Setup_VBLUno_Linux`
 
-`sudo ./Setup_VBLUno_Linux` 
+`sudo ./Setup_VBLUno_Linux`
 
-   * You have to wait until the program announce “The installation was successful” 
-  
+   * You have to wait until the program announce “The installation was successful”
+
   * Note: Preferences->Additional Boards Manager URLs always has this content (You can add multiple URLs, separating them with commas):
   `https://raw.githubusercontent.com/VNGIoTLab/Arduino_VBLUno_nRF51822/master/package_vngiotlab_vbluno_index.json`
 
 ## Bootloaders
-	
+
 * Bootloader helps Arduino IDE can upload firmware for VBLUno boards via serial ports.  VBLUno boards are sold , bootloaders are preloaded. **_Normally, you can skip this step._**
 
 * In the folder is named "VBLUno_nRF51822_board\bootloader", it contains bootloader_38400.hex and  source code.
@@ -286,7 +302,7 @@ You can install by one of two methods following
 **1. Connect VBLUno board to PC via USB port**
 
   * Switch bridge at jump J7 to position allow to upload firmware through serial ports (USB ports on VBLUno boards) by bootloaders (position 1-2, near black Power jack).
-     
+
   * Then press Reset button. At this time, two Leds on board are lighting up.
 
 **2. Open Arduino IDE**
@@ -297,7 +313,7 @@ You can install by one of two methods following
     * Menu > Tools > Board > VBLUno_V1_nRF51822_32KB(v1.0.4)
 
   * Select the serial port of VBLUno board:
-    * Menu > Tools > Port > [you board serial port name]
+    * Menu > Tools > Port > [your board's serial port name]
 
 **4. Blink**
 
@@ -305,9 +321,9 @@ You can install by one of two methods following
     * Menu > File > Examples > 01.Basics > Blink
 
   * Use the upload icon to load the sketch to your board.
-     
+
   * If it is compiled and uploaded successfully, you will be received the annoucement  “Device programmed”
-  
+
   * Switch bridge at jump J7 to position allow to run Application (position 2-3, near USB port).
 
 **5. BLE Examples**
@@ -325,7 +341,7 @@ You can install by one of two methods following
 	*BLE Controller*: This example allows you to use the BLE Controller App (available for iOS and Android) to control the pin state such as High, Low, PWM, Analog, etc.
 
 	*BLE Serial*: This example allows you to exchange data with your central device (e.g. iPhone 5) and the data will be redirected to the UART.
-	
+
 	*.....*
 
 


### PR DESCRIPTION
- Không nên chạy chương trình bằng user "root".
- Vấn đề truy cập cổng USB chỉ là vấn đề user có quyền đọc/ghi hay không. Cách chuẩn là dùng udev để đặt lại quyền cho cổng này để user hiện tại được phép truy cập, thay vì phải chạy chương trình bằng user "root".

PR cũng có sửa đổi vài ba chỗ tiếng Anh.